### PR TITLE
Set StatsBar to be open as default

### DIFF
--- a/MAP/src/components/StatsBar/StatsBar.js
+++ b/MAP/src/components/StatsBar/StatsBar.js
@@ -15,7 +15,7 @@ const StatsBar = ({
         lockdown: 0,
         affected: 0,
     });
-    const [isOpen, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     const toggleStatsBar = () => {
         setIsOpen(!isOpen);


### PR DESCRIPTION
StatsBar should be open after loading page without user input